### PR TITLE
Fetch all posters

### DIFF
--- a/app/controllers/api/v1/posters_controller.rb
+++ b/app/controllers/api/v1/posters_controller.rb
@@ -1,5 +1,5 @@
 class Api::V1::PostersController < ApplicationController
   def index
-    render json: Poster.all
+    render json: PosterSerializer.format_posters(Poster.all)
   end
 end

--- a/app/serializers/poster_serializer.rb
+++ b/app/serializers/poster_serializer.rb
@@ -1,0 +1,22 @@
+class PosterSerializer
+  def self.format_posters(posters)
+    poster_data = posters.map do |poster|
+      {
+        #id, type, attributes, name, description, year, price, vintage, url
+        id: poster.id,
+        type: "poster",
+        attributes: {
+          name: poster.name,
+          description: poster.description,
+          price: poster.price,
+          year: poster.year,
+          vintage: poster.vintage,
+          img_url: poster.img_url
+        }
+      }
+    end
+
+    return { data: poster_data }
+  end
+
+end

--- a/spec/requests/api/v1/posters_request_spec.rb
+++ b/spec/requests/api/v1/posters_request_spec.rb
@@ -1,0 +1,58 @@
+require "rails_helper"
+
+describe "hang_in_there_API", type: :request do
+  before(:each) do
+    Poster.create(name: "REGRET",
+    description: "Hard work rarely pays off.",
+    price: 89.00,
+    year: 2018,
+    vintage: true,
+    img_url:  "https://plus.unsplash.com/premium_photo-1661293818249-fddbddf07a5d")
+
+    Poster.create(name: "WOE",
+    description: "Life is an endless toil.",
+    price: 20.00,
+    year: 2016,
+    vintage: true,
+    img_url:  "https://plus.unsplash.com/premium_photo-1661293818249-fddbddf07a5d")
+
+    Poster.create(name: "MISERY",
+    description: "Why me God?",
+    price: 9.00,
+    year: 2008,
+    vintage: false,
+    img_url:  "https://plus.unsplash.com/premium_photo-1661293818249-fddbddf07a5d")
+  end
+
+  it "sends a list of posters" do
+    get "/api/v1/posters"
+
+    expect(response).to be_successful
+
+    poster_data = JSON.parse(response.body, symbolize_names: true)
+    expect(poster_data.count).to eq(1)
+    expect(poster_data[:data].count).to eq(3)
+    poster_data[:data].each do |poster|
+      expect(poster).to have_key(:id)
+      expect(poster[:id]).to be_a(Integer)
+      expect(poster).to have_key(:type)
+      expect(poster[:type]).to be_a(String)
+      expect(poster).to have_key(:attributes)
+      expect(poster[:attributes]).to be_a(Hash)
+      expect(poster[:attributes]).to have_key(:name)
+      expect(poster[:attributes][:name]).to be_a(String)
+      expect(poster[:attributes]).to have_key(:description)
+      expect(poster[:attributes][:description]).to be_a(String)
+      expect(poster[:attributes]).to have_key(:price)
+      expect(poster[:attributes][:price]).to be_a(Float)
+      expect(poster[:attributes]).to have_key(:year)
+      expect(poster[:attributes][:year]).to be_a(Integer)
+      expect(poster[:attributes]).to have_key(:vintage)
+      expect([true, false]).to include(poster[:attributes][:vintage])   #Weird way to write this test...maybe refactor later
+      expect(poster[:attributes]).to have_key(:img_url)
+      expect(poster[:attributes][:img_url]).to be_a(String)
+    end
+    
+  end
+
+end


### PR DESCRIPTION
Built out endpoint for fetching all posters.  Additional functionality includes:
-Serializer for formatting in correct JSON format
-RSpec test to verify correct structure for sample posters

Ready to merge with main.