### PR TITLE
Create and destroy

### DIFF
--- a/app/controllers/api/v1/posters_controller.rb
+++ b/app/controllers/api/v1/posters_controller.rb
@@ -5,8 +5,11 @@ class Api::V1::PostersController < ApplicationController
 
   def create
     # binding.pry
-    Poster.create(task_params())
+    # Poster.create(poster_params())
 
+    created_poster = Poster.create(poster_params())
+    render json: PosterSerializer.format_created_poster(created_poster)
+    #Could refactor later further probably.  Is this ok to still have in controller, or is it 'too much'?
 
 
     
@@ -14,35 +17,39 @@ class Api::V1::PostersController < ApplicationController
     #1. 'Cheap' way: create new object, save to DB, and format info from the object created.  Problem: we don't really know it's data in the DB, and we don't get id, etc.
     # created_poster = Poster.new(params[:poster])      #This doesn't seem to fully work
     
-    created_poster = Poster.new() do |p|
-      p.name = params[:poster][:name]
-      p.description = params[:poster][:description]
-      p.price = params[:poster][:price]
-      p.year = params[:poster][:year]
-      p.vintage = params[:poster][:vintage]
-      p.img_url = params[:poster][:img_url]
-    end
-    
+    # created_poster = Poster.new() do |p|
+    #   p.name = params[:poster][:name]
+    #   p.description = params[:poster][:description]
+    #   p.price = params[:poster][:price]
+    #   p.year = params[:poster][:year]
+    #   p.vintage = params[:poster][:vintage]
+    #   p.img_url = params[:poster][:img_url]
+    # end
+
     # binding.pry
 
-    created_poster.save()
-    #2. Full way: query the DB and return the relevant entry as an object to then serialize.
-    #This functionality should probably be eventually added to the model, yes?
-    # created_poster = Poster.order(created_at: :desc).limit(1)
-    #NOTE: this is NOT fully returning a poster object, even though it looks like it.  Doesn't have access to id, description, etc.  WHY?!
-    
+    # created_poster.save()
+    # #2. Full way: query the DB and return the relevant entry as an object to then serialize.
+    # #This functionality should probably be eventually added to the model, yes?
+    # # created_poster = Poster.order(created_at: :desc).limit(1)
+
     # binding.pry
 
-    render json: PosterSerializer.format_created_poster(created_poster)
+    # #NOTE: this is NOT fully returning a poster object, even though it looks like it.  Doesn't have access to id, description, etc.  WHY?!
+    
+    # # binding.pry
 
+    
   end
-
-
+  
+  
   private
-
-  def task_params()
+  
+  def poster_params()
     #For data validation purposes - STILL NEEDS MORE TESTING (will it accept other fields in the request and just ignore them?)
     params.require(:poster).permit(:name, :description, :img_url, :price, :year, :vintage)
+    #Joe did it this way and it worked as well:
+    # params.require(:data).require(:attributes).permit(:name, :description, :img_url, :price, :year, :vintage)
     # params.permit(:name, :description, :img_url, :price, :year, :vintage)
   end
 end

--- a/app/controllers/api/v1/posters_controller.rb
+++ b/app/controllers/api/v1/posters_controller.rb
@@ -41,6 +41,15 @@ class Api::V1::PostersController < ApplicationController
 
     
   end
+
+  def destroy()
+    #Just 204 status needs to be returned, no additional content
+    # binding.pry
+    
+    # render json: Poster.delete(params[:id], poster_params())
+    #Apparently poster_params() cannot be run with delete()?  Perhaps because the route forces it to only send one parameter (so we're automatically safe)?
+    render json: Poster.delete(params[:id])
+  end
   
   
   private

--- a/app/controllers/api/v1/posters_controller.rb
+++ b/app/controllers/api/v1/posters_controller.rb
@@ -2,4 +2,30 @@ class Api::V1::PostersController < ApplicationController
   def index
     render json: PosterSerializer.format_posters(Poster.all)
   end
+
+  def create
+    binding.pry
+    Poster.create(task_params())
+
+    binding.pry
+
+    #Two ways to do this.
+    #1. 'Cheap' way: create new object, save to DB, and format info from the object created.  Problem: we don't really know it's data in the DB, and we don't get id, etc.
+    #2. Full way: query the DB and return the relevant entry as an object to then serialize.
+    #This functionality should probably be eventually added to the model, yes?
+    created_poster = Poster.order(created_at: :desc).limit(1)
+
+    #Also expected to return JSON content!  What is the object to pass to this?  Poster.self / similar?
+    render json: PosterSerializer.format_created_poster(created_poster)
+
+  end
+
+
+  private
+
+  def task_params()
+    #For data validation purposes - STILL NEEDS MORE TESTING (will it accept other fields in the request and just ignore them?)
+    params.require(:poster).permit(:name, :description, :img_url, :price, :year, :vintage)
+    # params.permit(:name, :description, :img_url, :price, :year, :vintage)
+  end
 end

--- a/app/controllers/api/v1/posters_controller.rb
+++ b/app/controllers/api/v1/posters_controller.rb
@@ -4,18 +4,35 @@ class Api::V1::PostersController < ApplicationController
   end
 
   def create
-    binding.pry
+    # binding.pry
     Poster.create(task_params())
 
-    binding.pry
 
+
+    
     #Two ways to do this.
     #1. 'Cheap' way: create new object, save to DB, and format info from the object created.  Problem: we don't really know it's data in the DB, and we don't get id, etc.
+    # created_poster = Poster.new(params[:poster])      #This doesn't seem to fully work
+    
+    created_poster = Poster.new() do |p|
+      p.name = params[:poster][:name]
+      p.description = params[:poster][:description]
+      p.price = params[:poster][:price]
+      p.year = params[:poster][:year]
+      p.vintage = params[:poster][:vintage]
+      p.img_url = params[:poster][:img_url]
+    end
+    
+    # binding.pry
+
+    created_poster.save()
     #2. Full way: query the DB and return the relevant entry as an object to then serialize.
     #This functionality should probably be eventually added to the model, yes?
-    created_poster = Poster.order(created_at: :desc).limit(1)
+    # created_poster = Poster.order(created_at: :desc).limit(1)
+    #NOTE: this is NOT fully returning a poster object, even though it looks like it.  Doesn't have access to id, description, etc.  WHY?!
+    
+    # binding.pry
 
-    #Also expected to return JSON content!  What is the object to pass to this?  Poster.self / similar?
     render json: PosterSerializer.format_created_poster(created_poster)
 
   end

--- a/app/controllers/api/v1/posters_controller.rb
+++ b/app/controllers/api/v1/posters_controller.rb
@@ -4,48 +4,13 @@ class Api::V1::PostersController < ApplicationController
   end
 
   def create
-    # binding.pry
-    # Poster.create(poster_params())
-
     created_poster = Poster.create(poster_params())
     render json: PosterSerializer.format_created_poster(created_poster)
-    #Could refactor later further probably.  Is this ok to still have in controller, or is it 'too much'?
-
-
-    
-    #Two ways to do this.
-    #1. 'Cheap' way: create new object, save to DB, and format info from the object created.  Problem: we don't really know it's data in the DB, and we don't get id, etc.
-    # created_poster = Poster.new(params[:poster])      #This doesn't seem to fully work
-    
-    # created_poster = Poster.new() do |p|
-    #   p.name = params[:poster][:name]
-    #   p.description = params[:poster][:description]
-    #   p.price = params[:poster][:price]
-    #   p.year = params[:poster][:year]
-    #   p.vintage = params[:poster][:vintage]
-    #   p.img_url = params[:poster][:img_url]
-    # end
-
-    # binding.pry
-
-    # created_poster.save()
-    # #2. Full way: query the DB and return the relevant entry as an object to then serialize.
-    # #This functionality should probably be eventually added to the model, yes?
-    # # created_poster = Poster.order(created_at: :desc).limit(1)
-
-    # binding.pry
-
-    # #NOTE: this is NOT fully returning a poster object, even though it looks like it.  Doesn't have access to id, description, etc.  WHY?!
-    
-    # # binding.pry
-
-    
+    #Could refactor later further probably.  Is this ok to still have in controller, or is it 'too much'
   end
 
   def destroy()
-    #Just 204 status needs to be returned, no additional content
-    # binding.pry
-    
+    #Just 204 status needs to be returned, no additional content.  Right now returning code 200.  May need adjusting.
     # render json: Poster.delete(params[:id], poster_params())
     #Apparently poster_params() cannot be run with delete()?  Perhaps because the route forces it to only send one parameter (so we're automatically safe)?
     render json: Poster.delete(params[:id])

--- a/app/serializers/poster_serializer.rb
+++ b/app/serializers/poster_serializer.rb
@@ -19,8 +19,22 @@ class PosterSerializer
     return { data: poster_data }
   end
 
-  def self.format_created_poster()
-    
+  def self.format_created_poster(poster)
+    #Should refactor this later (lots of repeated w/ above format_posters())
+    return {
+      data: {
+        id: poster.id,
+        type: "poster",
+        attributes: {
+          name: poster.name,
+          description: poster.description,
+          price: poster.price,
+          year: poster.year,
+          vintage: poster.vintage,
+          img_url: poster.img_url
+        }
+      }
+    }
   end
 
 end

--- a/app/serializers/poster_serializer.rb
+++ b/app/serializers/poster_serializer.rb
@@ -19,4 +19,8 @@ class PosterSerializer
     return { data: poster_data }
   end
 
+  def self.format_created_poster()
+    
+  end
+
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -8,4 +8,5 @@ Rails.application.routes.draw do
   # Defines the root path route ("/")
   # root "posts#index"
   get "/api/v1/posters", to: "api/v1/posters#index"
+  post "/api/v1/posters", to: "api/v1/posters#create"
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -9,4 +9,5 @@ Rails.application.routes.draw do
   # root "posts#index"
   get "/api/v1/posters", to: "api/v1/posters#index"
   post "/api/v1/posters", to: "api/v1/posters#create"
+  delete "/api/v1/posters/:id", to: "api/v1/posters#destroy"
 end

--- a/spec/requests/api/v1/posters_request_spec.rb
+++ b/spec/requests/api/v1/posters_request_spec.rb
@@ -52,7 +52,39 @@ describe "hang_in_there_API", type: :request do
       expect(poster[:attributes]).to have_key(:img_url)
       expect(poster[:attributes][:img_url]).to be_a(String)
     end
-    
+  end
+
+  it "creates a new poster and returns appropriate response" do
+    incoming_valid_parameters = {
+      "name": "DEFEAT",
+      "description": "It's too late to start now.",
+      "price": 35.00,
+      "year": 2023,
+      "vintage": false,
+      "img_url":  "https://unsplash.com/photos/brown-brick-building-with-red-car-parked-on-the-side-mMV6Y0ExyIk"
+    }
+    headers = { "CONTENT_TYPE" => "application/json" }
+
+    post "/api/v1/posters", headers: headers, params: JSON.generate(poster: incoming_valid_parameters)
+
+    #Check for database being updated correctly.  Anything additional?
+    #Query DB:
+    newest_poster = Poster.last
+    # newest_poster = Poster.order(created_at: :desc)[0]
+
+    binding.pry
+
+    expect(response).to be_successful
+    #Also check the actual response (code + content)
+    expect(newest_poster.name).to eq(incoming_valid_parameters[:name])
+    expect(newest_poster.description).to eq(incoming_valid_parameters[:description])
+    expect(newest_poster.price).to eq(incoming_valid_parameters[:price])
+    expect(newest_poster.year).to eq(incoming_valid_parameters[:year])
+    expect(newest_poster.vintage).to eq(incoming_valid_parameters[:vintage])
+    expect(newest_poster.img_url).to eq(incoming_valid_parameters[:img_url])
+
+    #Later: also test invalid API data?
+
   end
 
 end

--- a/spec/requests/api/v1/posters_request_spec.rb
+++ b/spec/requests/api/v1/posters_request_spec.rb
@@ -72,7 +72,7 @@ describe "hang_in_there_API", type: :request do
     newest_poster = Poster.last
     # newest_poster = Poster.order(created_at: :desc)[0]
 
-    binding.pry
+    # binding.pry
 
     expect(response).to be_successful
     #Also check the actual response (code + content)
@@ -84,6 +84,25 @@ describe "hang_in_there_API", type: :request do
     expect(newest_poster.img_url).to eq(incoming_valid_parameters[:img_url])
 
     #Later: also test invalid API data?
+
+  end
+
+  it "deletes a specified poster from the database" do
+    #Create a temporary poster just for verifying deletion later
+    temp_poster = Poster.create(name: "APATHY", description: "I wouldn't be so apathetic if I weren't so lethargic")
+
+    
+    expect(Poster.count).to eq(4)   #Added one record on top of the three sample posters.  Might try the 'change.by' later...
+    
+    delete "/api/v1/posters/#{temp_poster.id}"
+    
+    # binding.pry
+
+    expect(response).to be_successful
+    expect(Poster.count).to eq(3)
+    expect{ (Poster.find(temp_poster.id)) }.to raise_error(ActiveRecord::RecordNotFound)      #WHY does this need {}'s to run correctly?  Because of how errors are evaluated?
+
+    #Later: could try to delete one of the earlier added ones too to verify it was removed, and also try to delete an nonexistent poster
 
   end
 

--- a/spec/requests/api/v1/posters_request_spec.rb
+++ b/spec/requests/api/v1/posters_request_spec.rb
@@ -70,9 +70,7 @@ describe "hang_in_there_API", type: :request do
     #Check for database being updated correctly.  Anything additional?
     #Query DB:
     newest_poster = Poster.last
-    # newest_poster = Poster.order(created_at: :desc)[0]
-
-    # binding.pry
+    newest_poster = Poster.order(created_at: :desc).limit(1)[0]
 
     expect(response).to be_successful
     #Also check the actual response (code + content)
@@ -96,8 +94,6 @@ describe "hang_in_there_API", type: :request do
     
     delete "/api/v1/posters/#{temp_poster.id}"
     
-    # binding.pry
-
     expect(response).to be_successful
     expect(Poster.count).to eq(3)
     expect{ (Poster.find(temp_poster.id)) }.to raise_error(ActiveRecord::RecordNotFound)      #WHY does this need {}'s to run correctly?  Because of how errors are evaluated?


### PR DESCRIPTION
Added create() and destroy() actions and associated endpoints.  Also built tests for each of these (additional edge cases can be added later).

This will likely cause merge conflict with serializer and poster_params() method - can work through together.