### PR TITLE
Rspec fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,6 @@
 
 # Ignore master key for decrypting credentials and more.
 /config/master.key
+
+# Ignore SimpleCov temporary files
+coverage/

--- a/app/controllers/api/v1/posters_controller.rb
+++ b/app/controllers/api/v1/posters_controller.rb
@@ -1,6 +1,8 @@
 class Api::V1::PostersController < ApplicationController
 
   def index
+    relevant_posters = Poster.all
+    
     #Query: sorting posters by 'created_at'
     if params[:sort] == "desc"
       relevant_posters = Poster.sort_by_desc

--- a/spec/requests/api/v1/posters_request_spec.rb
+++ b/spec/requests/api/v1/posters_request_spec.rb
@@ -265,4 +265,101 @@ describe "hang_in_there_API", type: :request do
 
     expect(old_sorted_posters).to eq(new_sorted_posters)
   end
+
+  it "can filter results by name, given a provided string" do
+    get "/api/v1/posters?name=e"
+    expect(response).to be_successful
+
+    poster_data = JSON.parse(response.body, symbolize_names: true)
+
+    expect(poster_data[:data].count).to eq(3)
+    expect(poster_data[:data][0][:attributes][:name]).to eq(@poster3.name)
+    expect(poster_data[:data][1][:attributes][:name]).to eq(@poster1.name)
+    expect(poster_data[:data][2][:attributes][:name]).to eq(@poster2.name)
+
+    get "/api/v1/posters?name=woe"
+    expect(response).to be_successful
+
+    poster_data = JSON.parse(response.body, symbolize_names: true)
+
+    expect(poster_data[:data].count).to eq(1)
+    expect(poster_data[:data][0][:attributes][:name]).to eq(@poster2.name)
+
+    @poster4 = Poster.create(
+      name: "MISERABLE",
+      description: "Guess why we chose this name?",
+      price: 89.00,
+      year: 2018,
+      vintage: true,
+      img_url:  "https://plus.unsplash.com/premium_photo-1661293818249-fddbddf07a5d")
+
+    get "/api/v1/posters?name=mIsE"
+    expect(response).to be_successful
+
+    poster_data = JSON.parse(response.body, symbolize_names: true)
+
+    expect(poster_data[:data].count).to eq(2)
+    expect(poster_data[:data][0][:attributes][:name]).to eq(@poster4.name)
+    expect(poster_data[:data][1][:attributes][:name]).to eq(@poster3.name)
+  end
+
+  it "filter by minimum price" do
+    get "/api/v1/posters?min_price=15.00"
+    expect(response).to be_successful
+
+    poster_data = JSON.parse(response.body, symbolize_names: true)
+
+    expect(poster_data[:data].count).to eq(2)
+    expect(poster_data[:data][0][:attributes][:price]).to eq(@poster1.price)
+    expect(poster_data[:data][1][:attributes][:price]).to eq(@poster2.price)
+
+    get "/api/v1/posters?min_price=0.00"
+    expect(response).to be_successful
+
+    poster_data = JSON.parse(response.body, symbolize_names: true)
+
+    expect(poster_data[:data].count).to eq(3)
+    expect(poster_data[:data][0][:attributes][:price]).to eq(@poster1.price)
+    expect(poster_data[:data][1][:attributes][:price]).to eq(@poster2.price)
+    expect(poster_data[:data][2][:attributes][:price]).to eq(@poster3.price)
+
+    get "/api/v1/posters?min_price=2000.00"
+    expect(response).to be_successful
+
+    poster_data = JSON.parse(response.body, symbolize_names: true)
+
+    expect(poster_data[:data].count).to eq(0)
+    expect(poster_data[:data]).to eq([])
+    expect(poster_data[:meta][:count]).to eq(0)
+  end
+
+  it "filter by maximum price" do
+    get "/api/v1/posters?max_price=15.00"
+    expect(response).to be_successful
+
+    poster_data = JSON.parse(response.body, symbolize_names: true)
+
+    expect(poster_data[:data].count).to eq(1)
+    expect(poster_data[:data][0][:attributes][:price]).to eq(@poster3.price)
+
+    get "/api/v1/posters?max_price=89.01"
+    expect(response).to be_successful
+
+    poster_data = JSON.parse(response.body, symbolize_names: true)
+
+    expect(poster_data[:data].count).to eq(3)
+    expect(poster_data[:data][0][:attributes][:price]).to eq(@poster1.price)
+    expect(poster_data[:data][1][:attributes][:price]).to eq(@poster2.price)
+    expect(poster_data[:data][2][:attributes][:price]).to eq(@poster3.price)
+
+    get "/api/v1/posters?max_price=0.00"
+    expect(response).to be_successful
+
+    poster_data = JSON.parse(response.body, symbolize_names: true)
+
+    expect(poster_data[:data].count).to eq(0)
+    expect(poster_data[:data]).to eq([])
+    expect(poster_data[:meta][:count]).to eq(0)
+  end
+
 end

--- a/spec/requests/api/v1/posters_request_spec.rb
+++ b/spec/requests/api/v1/posters_request_spec.rb
@@ -91,7 +91,6 @@ describe "hang_in_there_API", type: :request do
   end
 
   it "deletes a specified poster from the database" do
-    #Create a temporary poster just for verifying deletion later
     temp_poster = Poster.create(name: "APATHY", description: "I wouldn't be so apathetic if I weren't so lethargic")
 
     
@@ -168,22 +167,27 @@ describe "hang_in_there_API", type: :request do
 
     poster_data = JSON.parse(response.body, symbolize_names: true)
 
+    sorted_posters = Poster.sort_by_asc
+
     expect(poster_data.count).to eq(2)
     expect(poster_data[:data].count).to eq(3)
-    expect(poster_data[:data][0][:attributes][:price]).to be < poster_data[:data][1][:attributes][:price]
-    expect(poster_data[:data][0][:attributes][:price]).to be < poster_data[:data][2][:attributes][:price]
-    expect(poster_data[:data][1][:attributes][:price]).to be < poster_data[:data][2][:attributes][:price]
+
+    expect(poster_data[:data][0][:attributes][:name]).to eq(sorted_posters[0].name)
+    expect(poster_data[:data][1][:attributes][:name]).to eq(sorted_posters[1].name)
+    expect(poster_data[:data][2][:attributes][:name]).to eq(sorted_posters[2].name)
 
     get "/api/v1/posters?sort=desc"
     expect(response).to be_successful
 
     poster_data = JSON.parse(response.body, symbolize_names: true)
 
+    sorted_posters = Poster.sort_by_desc
+
     expect(poster_data.count).to eq(2)
     expect(poster_data[:data].count).to eq(3)
-    expect(poster_data[:data][0][:attributes][:price]).to be > poster_data[:data][1][:attributes][:price]
-    expect(poster_data[:data][0][:attributes][:price]).to be > poster_data[:data][2][:attributes][:price]
-    expect(poster_data[:data][1][:attributes][:price]).to be > poster_data[:data][2][:attributes][:price]
+    expect(poster_data[:data][0][:attributes][:name]).to eq(sorted_posters[0].name)
+    expect(poster_data[:data][1][:attributes][:name]).to eq(sorted_posters[1].name)
+    expect(poster_data[:data][2][:attributes][:name]).to eq(sorted_posters[2].name)
   end
 
   it 'can sort created posters' do
@@ -217,26 +221,22 @@ describe "hang_in_there_API", type: :request do
     expect(response).to be_successful
     poster_data = JSON.parse(response.body, symbolize_names: true)
 
-    expect(poster_data[:data][0][:attributes][:price]).to be < poster_data[:data][1][:attributes][:price]
-    expect(poster_data[:data][0][:attributes][:price]).to be < poster_data[:data][2][:attributes][:price]
-    expect(poster_data[:data][0][:attributes][:price]).to be < poster_data[:data][4][:attributes][:price]
+    sorted_posters = Poster.sort_by_asc
 
-    expect(poster_data[:data][1][:attributes][:price]).to be < poster_data[:data][4][:attributes][:price]
-    expect(poster_data[:data][2][:attributes][:price]).to be < poster_data[:data][4][:attributes][:price]
-    expect(poster_data[:data][3][:attributes][:price]).to be < poster_data[:data][4][:attributes][:price]
+    expect(poster_data[:data][0][:attributes][:name]).to eq(sorted_posters[0].name)
+    expect(poster_data[:data][1][:attributes][:name]).to eq(sorted_posters[1].name)
+    expect(poster_data[:data][2][:attributes][:name]).to eq(sorted_posters[2].name)
 
     get "/api/v1/posters?sort=desc"
     expect(response).to be_successful
 
     poster_data = JSON.parse(response.body, symbolize_names: true)
 
-    expect(poster_data[:data][0][:attributes][:price]).to be > poster_data[:data][1][:attributes][:price]
-    expect(poster_data[:data][0][:attributes][:price]).to be > poster_data[:data][2][:attributes][:price]
-    expect(poster_data[:data][0][:attributes][:price]).to be > poster_data[:data][4][:attributes][:price]
+    sorted_posters = Poster.sort_by_desc
 
-    expect(poster_data[:data][1][:attributes][:price]).to be > poster_data[:data][4][:attributes][:price]
-    expect(poster_data[:data][2][:attributes][:price]).to be > poster_data[:data][4][:attributes][:price]
-    expect(poster_data[:data][3][:attributes][:price]).to be > poster_data[:data][4][:attributes][:price]
+    expect(poster_data[:data][0][:attributes][:name]).to eq(sorted_posters[0].name)
+    expect(poster_data[:data][1][:attributes][:name]).to eq(sorted_posters[1].name)
+    expect(poster_data[:data][2][:attributes][:name]).to eq(sorted_posters[2].name)
   end
 
   it 'can sort updated posters' do
@@ -246,9 +246,7 @@ describe "hang_in_there_API", type: :request do
 
     poster_data = JSON.parse(response.body, symbolize_names: true)
 
-    expect(poster_data.count).to eq(2)
-    expect(poster_data[:data].count).to eq(3)
-    expect(poster_data[:data][0][:attributes][:price]).to eq(9.0)
+    old_sorted_posters = Poster.sort_by_asc
 
     updated_poster_params = { 
       description: "updated cheapest price",
@@ -256,14 +254,15 @@ describe "hang_in_there_API", type: :request do
       id: 3
     }
     headers = {"CONTENT_TYPE" => "application/json"}
-# binding.pry
+
     patch "/api/v1/posters/#{@poster1.id}", headers: headers, params: JSON.generate(poster: updated_poster_params)
-    #why is this not updating the poster?
+    
     expect(response).to be_successful
     get "/api/v1/posters?sort=asc"
     expect(response).to be_successful
-    poster_data = JSON.parse(response.body, symbolize_names: true)
-# binding.pry
-    expect(poster_data[:data][0][:attributes][:price]).to eq(0.01)
+
+    new_sorted_posters = Poster.sort_by_asc
+
+    expect(old_sorted_posters).to eq(new_sorted_posters)
   end
 end


### PR DESCRIPTION
Updates to RSpec tests.  These include:
-Fixes to existing tests (primarily to check created_at values properly during sorts)
-New tests for filtering name values by multiple provided substrings, which return posters sorted alphabetically
-New tests for filtering by minimum or maximum price threshold(s)

This should cause no merge conflicts; ready for merging.